### PR TITLE
Fix typo in get-examples script

### DIFF
--- a/get-examples.sh
+++ b/get-examples.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 DIR=`dirname $0`
-LLVM_VERSION=5.0.1git-ff6b4d3
+LLVM_VERSION=5.0.1
 if [ -z $LLVM_RELEASE_DIR ] ; then
 	LLVM_RELEASE_DIR=$DIR/llvm-release
 fi


### PR DESCRIPTION
I guess this is another typo that should be fixed